### PR TITLE
Fix for the change in INTERNAL-MAKE-LEXENV interface in sbcl 1.2.15

### DIFF
--- a/sbcl.lisp
+++ b/sbcl.lisp
@@ -3,19 +3,9 @@
 (in-package #:sb-c)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (flet ((version>= (version i ii iii)
-	   (multiple-value-bind (first first-dot)
-	       (parse-integer version :junk-allowed t)
-	     (if (>= first i)
-		 (multiple-value-bind (second second-dot)
-		     (parse-integer version :start (1+ first-dot)
-				    :junk-allowed t)
-		   (if (>= second ii)
-		       (>= (parse-integer version :start (1+ second-dot)
-					  :junk-allowed t)
-			   iii)))))))
-    (if (version>= (lisp-implementation-version) 1 2 15)
-	(pushnew :sbcl>=1.2.15 *features*))))
+  (if (= (length (sb-kernel:%simple-fun-arglist #'sb-c::internal-make-lexenv))
+         11)
+      (pushnew :sbcl-internal-make-lexenv-11 *features*)))
 
 (def-ir1-translator fart-current-lexenv ((&body body) start next result)
   (format t "current lexenv: ~a~%" *lexenv*)
@@ -38,7 +28,7 @@
 			 nil
 			 nil
 			 nil
-			 #+sbcl>=1.2.15 ',(lexenv-parent lexenv)
+			 #-sbcl-internal-make-lexenv-11 ',(lexenv-parent lexenv)
 			 ;; ,(lexenv-lambda *lexenv*)
 			 ;; ,(lexenv-cleanup *lexenv*)
 			 ;; ',(lexenv-handled-conditions *lexenv*)
@@ -59,8 +49,8 @@
 			nil
 			nil
 			nil
-			#+sbcl>=1.2.15 (lexenv-parent lexenv)))
-  
+			#-sbcl-internal-make-lexenv-11 (lexenv-parent lexenv)))
+
 (def-ir1-translator with-current-lexenv ((&body body) start next result)
   (ir1-convert start next result `(let ((,(intern "*LEXENV*") ,(sanitize-lexenv *lexenv*)))
 				    (declare (special ,(intern "*LEXENV*")))


### PR DESCRIPTION
The lexenv structure got a new field (parent) and INTERNAL-MAKE-LEXENV got a new parameter as needed.
Relevant git commit: https://github.com/sbcl/sbcl/commit/ad792784dac16d1d4de03afa72cb4e145e6d15bf

I check the sbcl version in use and push a symbol to _features_ if the version is bigger than 1.2.15. I then use this to conditionally compile the extra parameter in the function call.
My version check also works for version strings from the sbcl repos (they also carry an extra info that references the current state in the repo. Example: "1.2.15.abcdef"), but it does not consider the extra info and only checks the first 3 numbers.
